### PR TITLE
Core update and added an additional snap variables to snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,27 +1,21 @@
 name: pandoc-researchhacking
-version: 2.9.2.1
+version: '2.18'
 summary: Tool for converting from one markup format to another
 description: |
   Pandoc is a Haskell library for converting from one markup format to
   another, and a command-line tool that uses this library.
 confinement: strict
 grade: stable
-base: core18
+base: core20
 
 parts:
   pandoc-researchhacking:
     plugin: dump
-    source: https://github.com/jgm/pandoc/releases/download/$SNAPCRAFT_PROJECT_VERSION/pandoc-$SNAPCRAFT_PROJECT_VERSION-linux-amd64.tar.gz
+    source: https://github.com/jgm/pandoc/releases/download/$SNAPCRAFT_PROJECT_VERSION/pandoc-$SNAPCRAFT_PROJECT_VERSION-linux-$SNAPCRAFT_TARGET_ARCH.tar.gz
 
 apps:
   pandoc:
     command: bin/pandoc
-    plugs:
-      - home
-      - removable-media
-
-  pandoc-citeproc:
-    command: bin/pandoc-citeproc
     plugs:
       - home
       - removable-media


### PR DESCRIPTION
Added more recent image, update pandoc version, added some architecture awareness.  Note this is limited. The naming convention at the Pandoc GitHub website doesn't include the same strings used by snapcraft to identify hardware. Additionally since snap isn't compiling the Haskell codebase it doesn't support some architectures at all (e.g. s390, power pc).